### PR TITLE
chore: release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.1.0
+
+Improved
+- **Android & iOS**: Significantly enhanced watermark quality for both images and videos
+  - **Android**: High-quality filtering (FILTER_BITMAP_FLAG, DITHER_FLAG) with Matrix-based scaling for images; mipmaps + trilinear filtering (GL_LINEAR_MIPMAP_LINEAR) for video watermarks
+  - **iOS**: CILanczosScaleTransform for superior quality scaling (replaces simple CGAffineTransform); highQualityDownsample option added to CIContext
+  - Results in sharper, smoother watermarks with better detail preservation and anti-aliasing
+
+Example
+- Add save to gallery feature: users can now save watermarked images directly to their device photo library
+  - Cross-platform implementation using `gal` package with proper permission handling
+  - "Save to Gallery" button added to Result preview card
+
 ## 2.0.0
 
 Added

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: watermark_kit
 description: "Fast watermarking for Flutter (iOS + Android). Image/text overlays for images and videos without FFmpeg (Core Image/AVFoundation on iOS; MediaCodec + GLES on Android)."
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/tttocklll/watermark_kit
 repository: https://github.com/tttocklll/watermark_kit
 issue_tracker: https://github.com/tttocklll/watermark_kit/issues


### PR DESCRIPTION
## Release 2.1.0

This PR prepares the release for version 2.1.0.

### Changes in this Release

**Improved**
- **Android & iOS**: Significantly enhanced watermark quality for both images and videos
  - **Android**: High-quality filtering (FILTER_BITMAP_FLAG, DITHER_FLAG) with Matrix-based scaling for images; mipmaps + trilinear filtering (GL_LINEAR_MIPMAP_LINEAR) for video watermarks
  - **iOS**: CILanczosScaleTransform for superior quality scaling (replaces simple CGAffineTransform); highQualityDownsample option added to CIContext
  - Results in sharper, smoother watermarks with better detail preservation and anti-aliasing

**Example App**
- Add save to gallery feature: users can now save watermarked images directly to their device photo library
  - Cross-platform implementation using `gal` package with proper permission handling
  - "Save to Gallery" button added to Result preview card

### Files Updated
- `pubspec.yaml`: Version bumped from 2.0.0 to 2.1.0
- `CHANGELOG.md`: Added 2.1.0 release notes

### Next Steps
After merging this PR:
1. Create a GitHub release/tag `v2.1.0`
2. Publish to pub.dev using `flutter pub publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)