### PR TITLE
chore: release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2.1.1
+
+Fixed
+- **iOS**: Resolved crash in `composeText` when converting colorArgb (0xFFFFFFFF) from Int64 to UInt32
+  - Changed from unsafe `Int64 → Int32 → UInt32` conversion to idiomatic `UInt32(truncatingIfNeeded:)`
+  - Fixes "Fatal error: Not enough bits to represent the passed value" crash
+- **iOS**: Fixed text watermark clipping on right side
+  - Improved canvas size calculation using `CTLineGetImageBounds` in addition to `CTLineGetTypographicBounds`
+  - Ensures glyphs with italic, kerning, or ligatures are not clipped
+  - Increased padding from 4.0 to 8.0 for safety margin
+
 ## 2.1.0
 
 Improved

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: watermark_kit
 description: "Fast watermarking for Flutter (iOS + Android). Image/text overlays for images and videos without FFmpeg (Core Image/AVFoundation on iOS; MediaCodec + GLES on Android)."
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/tttocklll/watermark_kit
 repository: https://github.com/tttocklll/watermark_kit
 issue_tracker: https://github.com/tttocklll/watermark_kit/issues


### PR DESCRIPTION
## Release 2.1.1

This PR prepares the bugfix release for version 2.1.1.

### Changes in this Release

**Fixed**
- **iOS**: Resolved crash in `composeText` when converting colorArgb (0xFFFFFFFF) from Int64 to UInt32
  - Changed from unsafe `Int64 → Int32 → UInt32` conversion to idiomatic `UInt32(truncatingIfNeeded:)`
  - Fixes "Fatal error: Not enough bits to represent the passed value" crash
  - Resolves issue #2
- **iOS**: Fixed text watermark clipping on right side
  - Improved canvas size calculation using `CTLineGetImageBounds` in addition to `CTLineGetTypographicBounds`
  - Ensures glyphs with italic, kerning, or ligatures are not clipped
  - Increased padding from 4.0 to 8.0 for safety margin

### Files Updated
- `pubspec.yaml`: Version bumped from 2.1.0 to 2.1.1
- `CHANGELOG.md`: Added 2.1.1 release notes

### Related
- PR #5: iOS composeText crash and text clipping fixes
- Issue #2: Fatal error when using composeText

### Next Steps
After merging this PR:
1. Create a GitHub release/tag `v2.1.1`
2. Publish to pub.dev using `flutter pub publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)